### PR TITLE
Fix duplicate AJAX hook registration

### DIFF
--- a/admin/class-facility-locator-admin.php
+++ b/admin/class-facility-locator-admin.php
@@ -20,8 +20,7 @@ class Facility_Locator_Admin
         // Ensure tables exist
         $this->maybe_create_tables();
 
-        // Register AJAX actions
-        $this->register_ajax_actions();
+        // AJAX actions are hooked via Facility_Locator_Loader
     }
 
     /**


### PR DESCRIPTION
## Summary
- avoid registering admin AJAX handlers twice

## Testing
- `find . -name "*.php" | xargs -n 1 php -l` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841100da3f48327a9537b8c2bd7d2be